### PR TITLE
More detailed aging

### DIFF
--- a/optima_tb/databook.py
+++ b/optima_tb/databook.py
@@ -357,13 +357,6 @@ def loadSpreadsheetFunc(settings, databook_path):
                             data['transfers'][mig_type][pop_source] = odict()
                         data['transfers'][mig_type][pop_source][pop_target] = odict()
                         if mig_type == 'aging':
-                            if 'range' not in data['pops']['ages'][pop_source].keys():
-                                raise OptimaException('ERROR: An age transition has been flagged for a source population group with no age range.')
-                            else:
-                                data['transfers'][mig_type][pop_source][pop_target]['t'] = np.array([settings.tvec_start])
-                                data['transfers'][mig_type][pop_source][pop_target]['y'] = np.array([float(1/data['pops']['ages'][pop_source]['range'])])
-                                data['transfers'][mig_type][pop_source][pop_target]['y_format'] = 'Fraction'.lower()
-                                data['transfers'][mig_type][pop_source][pop_target]['y_factor'] = project_settings.DEFAULT_YFACTOR    # NOTE: Quick hack to make aging work with calibration branch.
                             if len(data['transfers'][mig_type][pop_source].keys()) > 1:
                                 raise OptimaException('ERROR: There are too many outgoing "%s" transitions listed for population "%s".' % (mig_type,pop_source))
         


### PR DESCRIPTION
Aging is still considered a default transfer that exists for all projects, but a user can now detail the values directly, rather than relying on an assumption based on age ranges provided in the population sheet.
The uniform-distribution assumption is still a default, but easily overwritten. Functionality in this branch has been tested by Gerard with Belarus.