### PR TITLE
Impact constraints implemented

### DIFF
--- a/optima_tb/defaults.py
+++ b/optima_tb/defaults.py
@@ -17,7 +17,7 @@ def defaultOptimOptions(settings, progset = None):
     
     options['progs_start'] = 2015.0
     options['init_alloc'] = odict()
-    options['constraints'] = {'limits':odict(), 'max_yearly_change':odict()}
+    options['constraints'] = {'limits':odict(), 'max_yearly_change':odict(), 'impacts':odict()}
     
     if not progset is None:
         for prog in progset.progs:
@@ -26,6 +26,8 @@ def defaultOptimOptions(settings, progset = None):
             options['constraints']['max_yearly_change'][prog.label] = {'val':np.inf, 'rel':True}
             if prog.func_specs['type'] == 'cost_only':
                 options['constraints']['limits'][prog.label]['vals'] = [1.0,1.0]
+        for impact in progset.impacts.keys():
+            options['constraints']['impacts'][impact] = {'vals':[0.0,np.inf]}
     options['orig_alloc'] = dcp(options['init_alloc'])
     
     options['constraints']['total'] = sum(options['init_alloc'].values())

--- a/optima_tb/model.py
+++ b/optima_tb/model.py
@@ -824,6 +824,12 @@ class Model(object):
                                         
                                 if first_prog: new_val = 0
                                 new_val += impact
+                                if 'constraints' in self.sim_settings and 'impacts' in self.sim_settings['constraints'] and par_label in self.sim_settings['constraints']['impacts']:
+                                    try: vals = self.sim_settings['constraints']['impacts'][par_label]['vals']
+                                    except: raise OptimaException('ERROR: An impact constraint was passed to the model for "%s" but had no values associated with it.' % par_label)
+                                    if not len(vals) == 2: raise OptimaException('ERROR: Constraints for impact "%s" must be provided as a list or tuple of two values, i.e. a lower and an upper constraint.' % par_label)
+                                    if new_val < vals[0]: new_val = vals[0]
+                                    if new_val > vals[1]: new_val = vals[1]
                                 first_prog = False
                 
                 for par in pars:


### PR DESCRIPTION
The defaults.py file introduces new constraints of the form
options['constraints']['impacts'][impact_par]['vals']. There is no
relative tag for this one.
It effectively restricts impact values after all modality interactions
(although technically it is checked following each modality interaction)
to be between the impact limits.