### PR TITLE
Coverage cap

### DIFF
--- a/optima_tb/model.py
+++ b/optima_tb/model.py
@@ -862,24 +862,24 @@ class Model(object):
                                         overflow_factor = self.prog_vals[prog_label]['cov'] / float(source_set_size)
                                 overflow_list.append(overflow_factor)
 
-                                year_check = 2015   # Hard-coded check.
-                                par_check = ['spdyes_rate','sndyes_rate']#['spdsuc_rate','spdno_rate']
-                                if par_label in par_check:
-                                    if self.sim_settings['tvec'][ti] >= year_check and self.sim_settings['tvec'][ti] < year_check + 0.5*settings.tvec_dt:
-                                        print('Year: %s' % self.sim_settings['tvec'][ti])
-                                        print('Program Name: %s' % prog.name)
-                                        print('Program %s: %f' % ('Coverage' if self.sim_settings['alloc_is_coverage'] else 'Budget', self.prog_vals[prog_label]['cost']))
-                                        print('Target Population: %s' % pop.label)
-                                        print('Target Parameter: %s' % par_label)
-                                        print('Unit Cost: %f' % prog.func_specs['pars']['unit_cost'])
-                                        print('Program Coverage: %f' % self.prog_vals[prog_label]['cov'])
-                                        print('Program Impact: %f' % net_impact)
-                                        print('Program Impact Format: %s' % prog.cov_format)
-                                        print('Source Compartment Size (Target Pop): %f' % source_element_size)
-                                        print('Source Compartment Size (Aggregated Over Target Pops): %f' % source_set_size)
-                                        print('Converted Impact: %f' % impact)
-                                        print('Converted Impact Format: %s' % pars[0].val_format)
-                                        print
+#                                year_check = 2015   # Hard-coded check.
+#                                par_check = ['spdno_rate','sndno_rate']#['spdsuc_rate','spdno_rate']
+#                                if par_label in par_check:
+#                                    if self.sim_settings['tvec'][ti] >= year_check and self.sim_settings['tvec'][ti] < year_check + 0.5*settings.tvec_dt:
+#                                        print('Year: %s' % self.sim_settings['tvec'][ti])
+#                                        print('Program Name: %s' % prog.name)
+#                                        print('Program %s: %f' % ('Coverage' if self.sim_settings['alloc_is_coverage'] else 'Budget', self.prog_vals[prog_label]['cost']))
+#                                        print('Target Population: %s' % pop.label)
+#                                        print('Target Parameter: %s' % par_label)
+#                                        print('Unit Cost: %f' % prog.func_specs['pars']['unit_cost'])
+#                                        print('Program Coverage: %f' % self.prog_vals[prog_label]['cov'])
+#                                        print('Program Impact: %f' % net_impact)
+#                                        print('Program Impact Format: %s' % prog.cov_format)
+#                                        print('Source Compartment Size (Target Pop): %f' % source_element_size)
+#                                        print('Source Compartment Size (Aggregated Over Target Pops): %f' % source_set_size)
+#                                        print('Converted Impact: %f' % impact)
+#                                        print('Converted Impact Format: %s' % pars[0].val_format)
+#                                        print
 
                                 if first_prog: 
                                     new_val = 0  # Zero out the new impact parameter for the first program that targets it within an update, just to make sure the overwrite works.
@@ -908,15 +908,15 @@ class Model(object):
 
                 for par in pars:
                     
-                    year_check = 2015   # Hard-coded check.
-                    par_check = ['spdyes_rate','sndyes_rate']#['spdsuc_rate','spdno_rate']
-                    if par_label in par_check:
-                        if self.sim_settings['tvec'][ti] >= year_check and self.sim_settings['tvec'][ti] < year_check + 0.5*settings.tvec_dt:
-                            print('Year: %s' % self.sim_settings['tvec'][ti])
-                            print('Target Population: %s' % pop.label)
-                            print('Target Parameter: %s' % par_label)
-                            print('Final Impact: %f' % new_val)
-                            print
+#                    year_check = 2015   # Hard-coded check.
+#                    par_check = ['spdno_rate','sndno_rate']#['spdsuc_rate','spdno_rate']
+#                    if par_label in par_check:
+#                        if self.sim_settings['tvec'][ti] >= year_check and self.sim_settings['tvec'][ti] < year_check + 0.5*settings.tvec_dt:
+#                            print('Year: %s' % self.sim_settings['tvec'][ti])
+#                            print('Target Population: %s' % pop.label)
+#                            print('Target Parameter: %s' % par_label)
+#                            print('Final Impact: %f' % new_val)
+#                            print
                     
                     par.vals[ti] = new_val
 


### PR DESCRIPTION
Before this PR, multiple programs would add their impacts (i.e. transition rates) together, which, if excessive, would then be blindly truncated to 100% as part of core population size updates.
However, this would not technically be appropriate if the maximum value of an impact parameter for one program was, e.g., 85%, while another program maxed out at 75% (i.e. when coverages reached 100% saturation).
The combined rate should thus always be somewhere between 75% and 85% for excessive coverage, regardless of funding, not 160% or greater truncated to 100%.
This commit thus tracks how 'excessive' coverage is for each program targeting a parameter, then renormalises impacts if the new excesses are over 100% of what can actually be covered.