### PR TITLE
Allow extrapolation to use np.nan

### DIFF
--- a/optima_tb/interpolation.py
+++ b/optima_tb/interpolation.py
@@ -11,7 +11,7 @@ import numpy as np
 
 #%% General interpolation wrapper
 
-def interpolateFunc(x, y, xnew, method = 'pchip'):
+def interpolateFunc(x, y, xnew, method = 'pchip', extrapolate_nan = False):
     '''
     Function that interpolates and extrapolates (x,y) coordinates along the domain subset of xnew, according to a chosen method.
     Works with numpy arrays to standardise output types. Input must be numpy array compatible.    
@@ -46,6 +46,11 @@ def interpolateFunc(x, y, xnew, method = 'pchip'):
     
     else:
         raise OptimaException('ERROR: Interpolation method "%s" not understood.' % method)
+        
+    # Replace extrapolated values with np.nan if this tag is marked True.
+    if extrapolate_nan:
+        ynew[xnew<x[0]] = np.nan
+        ynew[xnew>x[-1]] = np.nan
     
     return ynew
     


### PR DESCRIPTION
The general interpolateFunc() function now allows for extrapolated
values to be overwritten by np.nan if kwarg 'extrapolate_nan' is set to
True.
This has been propagated up to Parameter.interpolate(), where a
True-valued kwarg 'extrapolate_nan' will disable the par-vector padding
that produces 'flatlined' extrapolation.
Single-valued par-vectors will also be extended to two values for the
purpose of interpolation, with a dt of 1e-12. (This can be soft-coded
later if a tvec dt of less than 1e-12 is a real concern.)
This commit thus allows parameter extrapolation by np.nan.