### PR TITLE
Fix plotting levels

### DIFF
--- a/optima_tb/plotting.py
+++ b/optima_tb/plotting.py
@@ -1740,9 +1740,6 @@ def _plotTrends(ys, ts, labels, colors=None, y_hat=[], t_hat=[], plot_type=None,
 
     # plot ys, but reversed - and also reverse the labels (useful for scenarios, and optimizations):
     order_ys = range(len(ys))
-    if plot_type == PLOTTYPE_STACKED:
-        reverse_order = not reverse_order # Stacked plots are internally reversed to start with
-
     if reverse_order:
         logger.info("Reversing order of plot lines")
         order_ys = order_ys[::-1]  # surely there are more elegant ways to do this ...


### PR DESCRIPTION
This changes the behaviour of `separateLegends` to no longer support reversing the legend order. Instead, the legend order should be sensibly determined from the plotting script i.e. for stacked plots, it should automatically be reversed from the outset. Now, the only possibility for reversal is by setting `reverse_order=True` when calling `plotResults`, `plotCompareResults` or `plotPopulationCrossSection`, which will reverse both the layer/stacking order and the legend order. The legend order for separate legends should be the same as in `dev` plot mode